### PR TITLE
Backend/feature/register

### DIFF
--- a/backend/src/register/dtos/register-form-dto.ts
+++ b/backend/src/register/dtos/register-form-dto.ts
@@ -9,5 +9,5 @@ export class RegisterFormDto {
   birthdate: string;
   phoneNumber: string;
   profileImageUrl: string;
-  preferences: string;
+  preferences: string[];
 }

--- a/backend/src/register/register.module.ts
+++ b/backend/src/register/register.module.ts
@@ -5,12 +5,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserAuthRepository } from './repositories/user-auth.repository';
 import { TrainerProfileRepository } from './repositories/trainer-profile.repository';
 import { TraineeProfileRepository } from './repositories/trainee-profile.repository';
+import { Preference } from './entities/preference.entity';
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       UserAuthRepository,
       TrainerProfileRepository,
       TraineeProfileRepository,
+      Preference,
     ]),
   ],
   controllers: [RegisterController],

--- a/backend/src/register/repositories/trainee-profile.repository.ts
+++ b/backend/src/register/repositories/trainee-profile.repository.ts
@@ -1,12 +1,14 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { RegisterFormDto } from '../dtos/register-form-dto';
 import { TraineeProfile } from '../entities/trainee-profile.entity';
+import { Preference } from '../entities/preference.entity';
 
 @EntityRepository(TraineeProfile)
 export class TraineeProfileRepository extends Repository<TraineeProfile> {
   createUsingRegisterForm(
     userId: string,
     registerFormDto: RegisterFormDto,
+    preferences: Preference[],
   ): TraineeProfile {
     const {
       firstname,
@@ -26,6 +28,7 @@ export class TraineeProfileRepository extends Repository<TraineeProfile> {
     profile.birthdate = birthdate;
     profile.phoneNumber = phoneNumber;
     profile.profileImageUrl = profileImageUrl;
+    profile.preferences = preferences;
 
     return profile;
   }

--- a/backend/src/register/repositories/trainer-profile.repository.ts
+++ b/backend/src/register/repositories/trainer-profile.repository.ts
@@ -1,12 +1,14 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { RegisterFormDto } from '../dtos/register-form-dto';
 import { TrainerProfile } from '../entities/trainer-profile.entity';
+import { Preference } from '../entities/preference.entity';
 
 @EntityRepository(TrainerProfile)
 export class TrainerProfileRepository extends Repository<TrainerProfile> {
   createUsingRegisterForm(
     userId: string,
     registerFormDto: RegisterFormDto,
+    preferences: Preference[],
   ): TrainerProfile {
     const {
       firstname,
@@ -28,6 +30,7 @@ export class TrainerProfileRepository extends Repository<TrainerProfile> {
     profile.birthdate = birthdate;
     profile.phoneNumber = phoneNumber;
     profile.profileImageUrl = profileImageUrl;
+    profile.preferences = preferences;
 
     return profile;
   }


### PR DESCRIPTION
### Summary
When created user profile is being saved, also save user preferences
### Changes
- backend/src/register/dtos/register-form-dto.ts
  - `preferences` from `string` to be `string[]`, an array of uuid of preference
- backend/src/register/register.module.ts
  - Integrate typeorm features of `Preference`
- backend/src/register/register.service.ts
  - `selectedPreferences` is an array of `Preference` queried from database
  - Change from `insert` to `save` for cascading insertion
- backend/src/register/repositories/trainee-profile.repository.ts
  backend/src/register/repositories/trainer-profile.repository.ts
  - Add parameter `preference: Preference[]` and used for creating profile's preferences
### TODOs
- Reduce coupling code