### PR TITLE
Backend/feature/register

### DIFF
--- a/backend/init.sql
+++ b/backend/init.sql
@@ -40,18 +40,10 @@ INSERT INTO preference (id, name, svg_url) VALUES (UUID(), "Balance", "http://ww
 INSERT INTO preference (id, name, svg_url) VALUES (UUID(), "Flexibility", "http://www.svg.com/flexibility");
 INSERT INTO preference (id, name, svg_url) VALUES (UUID(), "Strength", "http://www.svg.com/strength");
 
-CREATE TABLE trainer_preference (
-    trainer_id VARCHAR(36),
+CREATE TABLE user_preference(
+    user_id VARCHAR(36),
     preference_id VARCHAR(36),
-    CONSTRAINT PK_user_preference PRIMARY KEY (trainer_id, preference_id),
-    CONSTRAINT FK_user_trainer_preference_trainer_id FOREIGN KEY (trainer_id) REFERENCES trainer(id) ON DELETE CASCADE,
-    CONSTRAINT FK_user_trainer_preference_preference_id FOREIGN KEY (preference_id) REFERENCES preference(id) ON DELETE CASCADE
-);
-
-CREATE TABLE trainee_preference (
-    trainee_id VARCHAR(36),
-    preference_id VARCHAR(36),
-    CONSTRAINT PK_user_preference PRIMARY KEY (trainee_id, preference_id),
-    CONSTRAINT FK_user_trainee_preference_trainee_id FOREIGN KEY (trainee_id) REFERENCES trainee(id) ON DELETE CASCADE,
-    CONSTRAINT FK_user_trainee_preference_preference_id FOREIGN KEY (preference_id) REFERENCES preference(id) ON DELETE CASCADE
+    CONSTRAINT PK_user_preference PRIMARY KEY (user_id, preference_id),
+    CONSTRAINT FK_user_preference_user_id FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE,
+    CONSTRAINT FK_user_preference_preference_id FOREIGN KEY (preference_id) REFERENCES preference(id) ON DELETE CASCADE
 );

--- a/backend/init.sql
+++ b/backend/init.sql
@@ -8,8 +8,7 @@ CREATE TABLE user (
 );
 
 CREATE TABLE trainer (
-    id VARCHAR(36) PRIMARY KEY,
-    user_id VARCHAR(36),
+    user_id VARCHAR(36) PRIMARY KEY,
     firstname VARCHAR(255),
     lastname VARCHAR(255),
     gender VARCHAR(10),
@@ -21,8 +20,7 @@ CREATE TABLE trainer (
 );
 
 CREATE TABLE trainee (
-    id VARCHAR(36) PRIMARY KEY,
-    user_id VARCHAR(36),
+    user_id VARCHAR(36) PRIMARY KEY,
     firstname VARCHAR(255),
     lastname VARCHAR(255),
     gender VARCHAR(10),

--- a/backend/src/entities/user.entity.ts
+++ b/backend/src/entities/user.entity.ts
@@ -1,4 +1,12 @@
-import { Entity, Column, JoinColumn, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  JoinColumn,
+  PrimaryGeneratedColumn,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
+import { Preference } from '../register/entities/preference.entity';
 
 @Entity({ name: 'user' })
 export class User {
@@ -14,4 +22,18 @@ export class User {
 
   @Column()
   salt: string;
+
+  @ManyToMany(() => Preference, { cascade: true })
+  @JoinTable({
+    name: 'user_preference',
+    joinColumn: {
+      name: 'user_id',
+      referencedColumnName: 'id',
+    },
+    inverseJoinColumn: {
+      name: 'preference_id',
+      referencedColumnName: 'id',
+    },
+  })
+  preferences: Preference[];
 }

--- a/backend/src/register/entities/trainee.entity.ts
+++ b/backend/src/register/entities/trainee.entity.ts
@@ -1,20 +1,9 @@
-import {
-  Entity,
-  Column,
-  OneToOne,
-  PrimaryGeneratedColumn,
-  ManyToMany,
-  JoinTable,
-} from 'typeorm';
+import { Entity, Column, OneToOne, PrimaryColumn } from 'typeorm';
 import { User } from '../../entities/user.entity';
-import { Preference } from './preference.entity';
 
 @Entity({ name: 'trainee' })
 export class Trainee {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
-  @Column({ name: 'user_id' })
+  @PrimaryColumn({ name: 'user_id' })
   @OneToOne(() => User, (user) => user.id)
   userId: string;
 
@@ -35,18 +24,4 @@ export class Trainee {
 
   @Column({ name: 'profile_image_url' })
   profileImageUrl: string;
-
-  @ManyToMany(() => Preference, { cascade: true })
-  @JoinTable({
-    name: 'trainee_preference',
-    joinColumn: {
-      name: 'trainee_id',
-      referencedColumnName: 'id',
-    },
-    inverseJoinColumn: {
-      name: 'preference_id',
-      referencedColumnName: 'id',
-    },
-  })
-  preferences: Preference[];
 }

--- a/backend/src/register/entities/trainer.entity.ts
+++ b/backend/src/register/entities/trainer.entity.ts
@@ -1,20 +1,8 @@
-import {
-  Entity,
-  Column,
-  OneToOne,
-  PrimaryGeneratedColumn,
-  ManyToMany,
-  JoinTable,
-} from 'typeorm';
+import { Entity, Column, OneToOne, PrimaryColumn } from 'typeorm';
 import { User } from '../../entities/user.entity';
-import { Preference } from './preference.entity';
-
 @Entity({ name: 'trainer' })
 export class Trainer {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
-  @Column({ name: 'user_id' })
+  @PrimaryColumn({ name: 'user_id' })
   @OneToOne(() => User, (user) => user.id)
   userId: string;
 
@@ -38,18 +26,4 @@ export class Trainer {
 
   @Column({ name: 'profile_image_url' })
   profileImageUrl: string;
-
-  @ManyToMany(() => Preference, { cascade: true })
-  @JoinTable({
-    name: 'trainer_preference',
-    joinColumn: {
-      name: 'trainer_id',
-      referencedColumnName: 'id',
-    },
-    inverseJoinColumn: {
-      name: 'preference_id',
-      referencedColumnName: 'id',
-    },
-  })
-  preferences: Preference[];
 }

--- a/backend/src/register/repositories/trainee.repository.ts
+++ b/backend/src/register/repositories/trainee.repository.ts
@@ -1,14 +1,12 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { RegisterFormDto } from '../dtos/register-form-dto';
 import { Trainee } from '../entities/trainee.entity';
-import { Preference } from '../entities/preference.entity';
 
 @EntityRepository(Trainee)
 export class TraineeRepository extends Repository<Trainee> {
   createUsingRegisterForm(
     userId: string,
     registerFormDto: RegisterFormDto,
-    preferences: Preference[],
   ): Trainee {
     const {
       firstname,
@@ -28,7 +26,6 @@ export class TraineeRepository extends Repository<Trainee> {
     profile.birthdate = birthdate;
     profile.phoneNumber = phoneNumber;
     profile.profileImageUrl = profileImageUrl;
-    profile.preferences = preferences;
 
     return profile;
   }

--- a/backend/src/register/repositories/trainer.repository.ts
+++ b/backend/src/register/repositories/trainer.repository.ts
@@ -1,14 +1,12 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { RegisterFormDto } from '../dtos/register-form-dto';
 import { Trainer } from '../entities/trainer.entity';
-import { Preference } from '../entities/preference.entity';
 
 @EntityRepository(Trainer)
 export class TrainerRepository extends Repository<Trainer> {
   createUsingRegisterForm(
     userId: string,
     registerFormDto: RegisterFormDto,
-    preferences: Preference[],
   ): Trainer {
     const {
       firstname,
@@ -30,7 +28,6 @@ export class TrainerRepository extends Repository<Trainer> {
     profile.birthdate = birthdate;
     profile.phoneNumber = phoneNumber;
     profile.profileImageUrl = profileImageUrl;
-    profile.preferences = preferences;
 
     return profile;
   }

--- a/backend/src/register/repositories/user.repository.ts
+++ b/backend/src/register/repositories/user.repository.ts
@@ -1,16 +1,18 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { User } from '../../entities/user.entity';
 import { RegisterFormDto } from '../dtos/register-form-dto';
+import { Preference } from '../entities/preference.entity';
 import * as bcrypt from 'bcryptjs';
-
 @EntityRepository(User)
 export class UserRepository extends Repository<User> {
   async createUsingRegisterForm(
     registerFormDto: RegisterFormDto,
+    preferences: Preference[],
   ): Promise<User> {
     const { email, password } = registerFormDto;
     const user = this.create();
     user.email = email;
+    user.preferences = preferences;
     // TODO: refactor duplicate hash logic
     // #region hash password
     const saltRounds = 10;


### PR DESCRIPTION
### Summary
- Remove `trainer_preference` and `trainee_preference`
- Use `user_preference` instead
- Restructure entities, repositories and service

### Changes
- backend/init.sql
  - Removed `id` from `trainer`
  - Removed `id` from `trainee`
  - Removed `trainer_preference`
  - Removed `trainee_preference`
  - Added `user_preference`
- backend/src/entities/user.entity.ts
  - Added column `preferences`
- backend/src/register/entities/trainee.entity.ts
  backend/src/register/entities/trainer.entity.ts
  - Removed column `id`
  - Change column `user_id` to be a primary column
  - Removed column `preferences`
- backend/src/register/register.service.ts
  - Restructure the service
- backend/src/register/repositories/trainee.repository.ts
  backend/src/register/repositories/trainer.repository.ts
  - Removed parameter `preferences`
- backend/src/register/repositories/user.repository.ts
  - Added parameter `preferences`

For database diagram, sees https://dbdiagram.io/d/601e92ec80d742080a396e7c