### PR TITLE
Backend/feature/profile

### DIFF
--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -1,24 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import * as jwt from 'jsonwebtoken';
-import { Trainer } from 'src/entities/trainer.entity';
-import { Trainee } from 'src/entities/trainee.entity';
 import * as config from 'config';
 
 const authConfig = config.get('auth');
-
-export interface TraineeProfileDto {
-  id: string;
-  email: string;
-  type: string;
-  profile: Trainee;
-}
-
-export interface TrainerProfileDto {
-  id: string;
-  email: string;
-  type: string;
-  profile: Trainer;
-}
 
 export class AuthUserGetter {
   public id: string;

--- a/backend/src/profile/dtos/trainee-profile-dto.ts
+++ b/backend/src/profile/dtos/trainee-profile-dto.ts
@@ -1,8 +1,7 @@
 import { Trainee } from 'src/entities/trainee.entity';
+import { Preference } from '../../preference/entities/preference.entity';
 
-export interface TraineeProfileDto {
-  id: string;
+export interface TraineeProfileDto extends Trainee {
   email: string;
-  type: string;
-  profile: Trainee;
+  preferences: Preference[];
 }

--- a/backend/src/profile/dtos/trainee-profile-dto.ts
+++ b/backend/src/profile/dtos/trainee-profile-dto.ts
@@ -1,7 +1,9 @@
 import { Trainee } from 'src/entities/trainee.entity';
 import { Preference } from '../../preference/entities/preference.entity';
+import { UserType } from '../../register/enums/user-type.enum';
 
 export interface TraineeProfileDto extends Trainee {
   email: string;
+  type: UserType;
   preferences: Preference[];
 }

--- a/backend/src/profile/dtos/trainer-profile-dto.ts
+++ b/backend/src/profile/dtos/trainer-profile-dto.ts
@@ -1,8 +1,7 @@
 import { Trainer } from 'src/entities/trainer.entity';
+import { Preference } from '../../preference/entities/preference.entity';
 
-export interface TrainerProfileDto {
-  id: string;
+export interface TrainerProfileDto extends Trainer {
   email: string;
-  type: string;
-  profile: Trainer;
+  preferences: Preference[];
 }

--- a/backend/src/profile/dtos/trainer-profile-dto.ts
+++ b/backend/src/profile/dtos/trainer-profile-dto.ts
@@ -1,7 +1,9 @@
 import { Trainer } from 'src/entities/trainer.entity';
 import { Preference } from '../../preference/entities/preference.entity';
+import { UserType } from '../../register/enums/user-type.enum';
 
 export interface TrainerProfileDto extends Trainer {
   email: string;
+  type: UserType;
   preferences: Preference[];
 }

--- a/backend/src/profile/profile.controller.ts
+++ b/backend/src/profile/profile.controller.ts
@@ -10,7 +10,7 @@ export class ProfileController {
 
   @Get()
   @UseGuards(AuthGuard)
-  async me(
+  async getProfile(
     @Req() request: LetXRequest,
   ): Promise<TrainerProfileDto | TraineeProfileDto> {
     return this.profileService.getProfileFromRequest(request);

--- a/backend/src/profile/profile.controller.ts
+++ b/backend/src/profile/profile.controller.ts
@@ -1,12 +1,9 @@
 import { Controller, Req, Get, UseGuards } from '@nestjs/common';
 import { ProfileService } from './profile.service';
-import {
-  LetXRequest,
-  TrainerProfileDto,
-  TraineeProfileDto,
-} from 'src/middlewares/auth.middleware';
+import { LetXRequest } from 'src/middlewares/auth.middleware';
 import { AuthGuard } from '../guards/auth.guard';
-
+import { TrainerProfileDto } from './dtos/trainer-profile-dto';
+import { TraineeProfileDto } from './dtos/trainee-profile-dto';
 @Controller('profile')
 export class ProfileController {
   constructor(private profileService: ProfileService) {}

--- a/backend/src/profile/profile.service.ts
+++ b/backend/src/profile/profile.service.ts
@@ -5,13 +5,9 @@ import { User } from '../entities/user.entity';
 import { Trainer } from 'src/entities/trainer.entity';
 import { Trainee } from 'src/entities/trainee.entity';
 import { UserType } from 'src/register/enums/user-type.enum';
-import {
-  LetXRequest,
-  TrainerProfileDto,
-  TraineeProfileDto,
-  AuthUserGetter,
-} from 'src/middlewares/auth.middleware';
-
+import { LetXRequest, AuthUserGetter } from 'src/middlewares/auth.middleware';
+import { TrainerProfileDto } from './dtos/trainer-profile-dto';
+import { TraineeProfileDto } from './dtos/trainee-profile-dto';
 @Injectable()
 export class ProfileService {
   constructor(

--- a/backend/src/profile/profile.service.ts
+++ b/backend/src/profile/profile.service.ts
@@ -28,19 +28,25 @@ export class ProfileService {
   }
 
   async loadProfile(
-    user: AuthUserGetter,
+    authUser: AuthUserGetter,
   ): Promise<TraineeProfileDto | TrainerProfileDto> {
-    const profile = await this.resolveRepository(user.type).findOneOrFail({
+    const user = await this.userRepository.findOneOrFail({
+      where: {
+        id: authUser.id,
+      },
+      relations: ['preferences'],
+    });
+
+    const profile = await this.resolveRepository(authUser.type).findOneOrFail({
       where: {
         userId: user.id,
       },
     });
 
     return {
-      id: user.id,
+      ...profile,
       email: user.email,
-      type: user.type,
-      profile: profile,
+      preferences: user.preferences,
     };
   }
 

--- a/backend/src/profile/profile.service.ts
+++ b/backend/src/profile/profile.service.ts
@@ -46,6 +46,7 @@ export class ProfileService {
     return {
       ...profile,
       email: user.email,
+      type: authUser.type as UserType,
       preferences: user.preferences,
     };
   }


### PR DESCRIPTION
### Summary
Refactor some GET profile logic

### Problems
- There are duplicate profile DTO interfaces
- The profile DTOs don't attach preferences
- The structure of profile DTOs aren't flatten
- The controller function name is `me`

### Changes
- backend/src/middlewares/auth.middleware.ts
  - Remove unnecessary `TrainerProfileDto` and `TraineeProfileDto`
- backend/src/profile/dtos/trainer-profile-dto.ts
  backend/src/profile/dtos/trainee-profile-dto.ts
  - Change type of `type` from `string` to `UserType`
  - Add `preferences`
- backend/src/profile/profile.controller.ts
  - Restructured imports
  - Change controller function name to `getProfile`
- backend/src/profile/profile.service.ts
  - Restructured imports
  - In `loadProfile` function, parameter changed from `user` to `authUser` indicate that it comes from token data
  - Also get `user` with their `preferences` from database
  - Return combined data of `user`, `authUser` and `profile`

### Result
Screenshot are taken from Postman
**Before**
<img width="1341" alt="Screen Shot 2564-02-23 at 01 03 27" src="https://user-images.githubusercontent.com/31557078/108749882-f3af3700-7572-11eb-9b91-bf7f3aba289b.png">
**After**
<img width="1341" alt="Screen Shot 2564-02-23 at 01 05 29" src="https://user-images.githubusercontent.com/31557078/108750113-3a9d2c80-7573-11eb-8b5f-caa91534ae19.png">

