### PR TITLE
Backend/feature/us4-3

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { RegisterModule } from './register/register.module';
 import { LoginModule } from './login/login.module';
 import { ProfileModule } from './profile/profile.module';
 import { PreferenceModule } from './preference/preference.module';
+import { TrainerModule } from './trainer/trainer.module';
 import * as config from 'config';
 
 const dbConfig = config.get('db');
@@ -27,6 +28,7 @@ const dbConfig = config.get('db');
     LoginModule,
     ProfileModule,
     PreferenceModule,
+    TrainerModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/trainer/dtos/trainer-search-criteria-dto.ts
+++ b/backend/src/trainer/dtos/trainer-search-criteria-dto.ts
@@ -1,0 +1,3 @@
+export class TrainerSearchCriteriaDto {
+  preferences: string[];
+}

--- a/backend/src/trainer/trainer.controller.ts
+++ b/backend/src/trainer/trainer.controller.ts
@@ -1,0 +1,16 @@
+import { Body, Controller, Get } from '@nestjs/common';
+import { Trainer } from '../entities/trainer.entity';
+import { TrainerService } from './trainer.service';
+import { TrainerSearchCriteriaDto } from './dtos/trainer-search-criteria-dto';
+
+@Controller('trainer')
+export class TrainerController {
+  constructor(private trainerService: TrainerService) {}
+
+  @Get('search')
+  async search(
+    @Body() trainerSearchCriteriaDto: TrainerSearchCriteriaDto,
+  ): Promise<Trainer[]> {
+    return this.trainerService.search(trainerSearchCriteriaDto);
+  }
+}

--- a/backend/src/trainer/trainer.controller.ts
+++ b/backend/src/trainer/trainer.controller.ts
@@ -7,10 +7,12 @@ import { TrainerSearchCriteriaDto } from './dtos/trainer-search-criteria-dto';
 export class TrainerController {
   constructor(private trainerService: TrainerService) {}
 
-  @Get('search')
-  async search(
+  @Get('preferences')
+  async getTrainersByPreferences(
     @Body() trainerSearchCriteriaDto: TrainerSearchCriteriaDto,
   ): Promise<Trainer[]> {
-    return this.trainerService.search(trainerSearchCriteriaDto);
+    return this.trainerService.getTrainersByPreferences(
+      trainerSearchCriteriaDto,
+    );
   }
 }

--- a/backend/src/trainer/trainer.module.ts
+++ b/backend/src/trainer/trainer.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TrainerController } from './trainer.controller';
+import { TrainerService } from './trainer.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TrainerRepository } from '../register/repositories/trainer.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TrainerRepository])],
+  controllers: [TrainerController],
+  providers: [TrainerService],
+})
+export class TrainerModule {}

--- a/backend/src/trainer/trainer.service.ts
+++ b/backend/src/trainer/trainer.service.ts
@@ -13,7 +13,7 @@ export class TrainerService {
     private connection: Connection,
   ) {}
 
-  async search(
+  async getTrainersByPreferences(
     trainerSearchCriteriaDto: TrainerSearchCriteriaDto,
   ): Promise<Trainer[]> {
     const { preferences } = trainerSearchCriteriaDto;

--- a/backend/src/trainer/trainer.service.ts
+++ b/backend/src/trainer/trainer.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { Trainer } from 'src/entities/trainer.entity';
+import { TrainerSearchCriteriaDto } from './dtos/trainer-search-criteria-dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { TrainerRepository } from '../register/repositories/trainer.repository';
+import { Connection, In } from 'typeorm';
+
+@Injectable()
+export class TrainerService {
+  constructor(
+    @InjectRepository(Trainer)
+    private trainerRepository: TrainerRepository,
+    private connection: Connection,
+  ) {}
+
+  async search(
+    trainerSearchCriteriaDto: TrainerSearchCriteriaDto,
+  ): Promise<Trainer[]> {
+    const { preferences } = trainerSearchCriteriaDto;
+
+    const userPreferences = await this.connection
+      .createQueryBuilder()
+      .select('up.user_id')
+      .distinct(true)
+      .from('user_preference', 'up')
+      .where('up.preference_id IN (:...preferenceIds)', {
+        preferenceIds: preferences,
+      })
+      .getRawMany();
+
+    const userIds = userPreferences.map(
+      (userPreference) => userPreference['up_user_id'],
+    );
+
+    const trainers = await this.trainerRepository
+      .createQueryBuilder('trainer')
+      .select([
+        'trainer.firstname',
+        'trainer.lastname',
+        'trainer.profileImageUrl',
+        'user.id',
+        'preference',
+      ])
+      .innerJoin('trainer.user', 'user')
+      .innerJoin('user.preferences', 'preference')
+      .where('user.id IN (:...userIds)', {
+        userIds,
+      })
+      .getMany();
+
+    return trainers;
+  }
+}

--- a/backend/src/trainer/trainer.service.ts
+++ b/backend/src/trainer/trainer.service.ts
@@ -39,7 +39,8 @@ export class TrainerService {
         'trainer.lastname',
         'trainer.profileImageUrl',
         'user.id',
-        'preference',
+        'preference.id',
+        'preference.name',
       ])
       .innerJoin('trainer.user', 'user')
       .innerJoin('user.preferences', 'preference')


### PR DESCRIPTION
## Summary
**US4-3** As a trainee, I want to view all trainer list, so that I can get the trainer that is most suitable for me

This PR also covered these features
- **US4-1** As a trainee, I want to filter out the trainer based on my preferred categories, so that I get the trainer that most suitable for me
- **US4-4** As a trainer, I want to filter out the trainer based on my preferred categories, so that I see the trend of trainers
- **US4-6** As a trainer, I want to view all trainer list, so that I can see big picture of trainer trend

Add GET `/trainer/preferences`

The schema of `TrainerSearchCriteriaDto`
```
{
  preferences: string[]
}
```
The schema of response
```
[
  Trainer {
    firstname: string,
    lastname: string,
    profileImageUrl: string,
    user: [
      User {
        id
        preferences: [
          Preference {
            id: string,
            name: string
          }
        ]
      }
    ]
  }
]
```

## Changes
- backend/src/app.module.ts
  - Add `TrainerModule`
- backend/src/trainer/dtos/trainer-search-criteria-dto.ts
  - Add body dto, contains only preferences
- backend/src/trainer/trainer.controller.ts
  - Add `Trainer` controller and GET `/preferences`
- backend/src/trainer/trainer.module.ts
  - Add `Trainer` module
- backend/src/trainer/trainer.service.ts
  - Add `Trainer` service
  - ⚠️ Since there is no `UserPreference` entity, hence used raw query.
  - ⚠️ Assumed that the search feature only required for trainer's firstname, lastname, profileImageUrl and preferences.

## Result
Assume that there is
- 'trainer1' who preferred 'Cardiovascular' and 'Balance'
- 'trainer2' who preferred 'Cardiovascular' and 'Flexibility'
- 'trainee' as a dummy trainee

**NOTE:** After being updated, there are some minor changes
- Endpoint changed to `trainer/preferences`
- No `svg_url`

| When searching for 'Cardiovascular' | When searching for 'Balance' | When searching for 'Flexibility' | When searching for 'Balance' and 'Flexibility' |
| -- | -- | -- | -- |
| <img width="1336" alt="Screen Shot 2564-03-02 at 21 15 34" src="https://user-images.githubusercontent.com/31557078/109661313-6f753900-7b9c-11eb-8f1f-984d40e28992.png"> | <img width="1336" alt="Screen Shot 2564-03-02 at 21 16 27" src="https://user-images.githubusercontent.com/31557078/109661437-90d62500-7b9c-11eb-92c2-295489afa7ff.png"> | <img width="1336" alt="Screen Shot 2564-03-02 at 21 17 14" src="https://user-images.githubusercontent.com/31557078/109661552-ab100300-7b9c-11eb-9194-d0de350b598e.png"> | <img width="1336" alt="Screen Shot 2564-03-02 at 21 18 26" src="https://user-images.githubusercontent.com/31557078/109661692-d5fa5700-7b9c-11eb-93c2-f4f3801cf775.png"> |