### PR TITLE
Backend/feature/us5-1

### DIFF
--- a/backend/mysql-script/1-init.sql
+++ b/backend/mysql-script/1-init.sql
@@ -92,10 +92,12 @@ CREATE TABLE review(
     id VARCHAR(36) PRIMARY KEY,
     trainee_user_id VARCHAR(36),
     trainer_user_id VARCHAR(36),
+    application_id VARCHAR(36) UNIQUE,
     comment VARCHAR(1000),
     rating TINYINT UNSIGNED,
     CONSTRAINT FK_review_trainee_user_id FOREIGN KEY (trainee_user_id) REFERENCES trainee(user_id) ON DELETE CASCADE,
-    CONSTRAINT FK_review_trainer_user_id FOREIGN KEY (trainer_user_id) REFERENCES trainer(user_id) ON DELETE CASCADE
+    CONSTRAINT FK_review_trainer_user_id FOREIGN KEY (trainer_user_id) REFERENCES trainer(user_id) ON DELETE CASCADE,
+    CONSTRAINT FK_review_application_id FOREIGN KEY (application_id) REFERENCES application(id) ON DELETE CASCADE
 );
 
 CREATE TABLE faq(

--- a/backend/mysql-script/3-data.sql
+++ b/backend/mysql-script/3-data.sql
@@ -58,12 +58,13 @@ INSERT INTO course VALUES ("course-id-4","Course Title 4","description","interme
 
 INSERT INTO application VALUES ("application-id-0","user-id-0","course-id-0","pending");
 INSERT INTO application VALUES ("application-id-1","user-id-0","course-id-1","pending");
+INSERT INTO application VALUES ("application-id-2","user-id-0","course-id-1","complete");
 
 -- Mock Review --
-INSERT INTO review VALUES (UUID(), "user-id-6", "user-id-3", "You are good", 5);
-INSERT INTO review VALUES (UUID(), "user-id-6", "user-id-3", "You are bad", 2);
-INSERT INTO review VALUES (UUID(), "user-id-6", "user-id-4", "You are bad", 2);
-INSERT INTO review VALUES (UUID(), "user-id-6", "user-id-5", "You are bad", 3);
+-- INSERT INTO review VALUES (UUID(), "user-id-6", "user-id-3", "You are good", 5);
+-- INSERT INTO review VALUES (UUID(), "user-id-6", "user-id-3", "You are bad", 2);
+-- INSERT INTO review VALUES (UUID(), "user-id-6", "user-id-4", "You are bad", 2);
+-- INSERT INTO review VALUES (UUID(), "user-id-6", "user-id-5", "You are bad", 3);
 
 -- Mock FAQ --
 INSERT INTO faq VALUES (UUID(), "user-id-2", "can a private course with a specific requirements be requested ?", "yes, just send requirements to my chat.");

--- a/backend/mysql-script/3-data.sql
+++ b/backend/mysql-script/3-data.sql
@@ -58,7 +58,7 @@ INSERT INTO course VALUES ("course-id-4","Course Title 4","description","interme
 
 INSERT INTO application VALUES ("application-id-0","user-id-0","course-id-0","pending");
 INSERT INTO application VALUES ("application-id-1","user-id-0","course-id-1","pending");
-INSERT INTO application VALUES ("application-id-2","user-id-0","course-id-1","complete");
+INSERT INTO application VALUES ("application-id-2","user-id-0","course-id-2","complete");
 
 -- Mock Review --
 -- INSERT INTO review VALUES (UUID(), "user-id-6", "user-id-3", "You are good", 5);

--- a/backend/src/review/dtos/create-review-dto.ts
+++ b/backend/src/review/dtos/create-review-dto.ts
@@ -1,5 +1,5 @@
 export class CreateReviewDto {
-  trainerUserId: string;
+  applicationId: string;
   rating: number;
   comment: string;
 }

--- a/backend/src/review/entities/review.entity.ts
+++ b/backend/src/review/entities/review.entity.ts
@@ -4,9 +4,11 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
   Column,
+  OneToOne,
 } from 'typeorm';
 import { Trainer } from '../../entities/trainer.entity';
 import { Trainee } from '../../entities/trainee.entity';
+import { Application } from '../../application/entities/application.entity';
 
 @Entity({ name: 'review' })
 export class Review {
@@ -20,6 +22,10 @@ export class Review {
   @ManyToOne(() => Trainer, (trainer) => trainer.reviews)
   @JoinColumn({ name: 'trainer_user_id', referencedColumnName: 'userId' })
   trainer: Trainer;
+
+  @OneToOne(() => Application)
+  @JoinColumn({ name: 'application_id', referencedColumnName: 'id' })
+  application: Application;
 
   @Column()
   comment: string;

--- a/backend/src/review/review.module.ts
+++ b/backend/src/review/review.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ReviewService } from './review.service';
 import { ReviewController } from './review.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Review } from './entities/review.entity';
+import { Application } from '../application/entities/application.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Review, Application])],
   providers: [ReviewService],
   controllers: [ReviewController],
 })

--- a/backend/src/review/review.service.ts
+++ b/backend/src/review/review.service.ts
@@ -3,6 +3,8 @@ import {
   ForbiddenException,
   Injectable,
   NotFoundException,
+  InternalServerErrorException,
+  ConflictException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -12,7 +14,6 @@ import {
   ApplicationStatus,
 } from '../application/entities/application.entity';
 import { CreateReviewDto } from './dtos/create-review-dto';
-import { InternalServerErrorException } from '@nestjs/common';
 
 @Injectable()
 export class ReviewService {
@@ -59,9 +60,7 @@ export class ReviewService {
       return await this.reviewRepository.save(review);
     } catch (error) {
       if (error.code === 'ER_DUP_ENTRY') {
-        throw new BadRequestException(
-          'The review of appliation already exists',
-        );
+        throw new ConflictException('The review of appliation already exists');
       } else {
         throw new InternalServerErrorException();
       }

--- a/backend/src/review/review.service.ts
+++ b/backend/src/review/review.service.ts
@@ -1,16 +1,71 @@
-import { Injectable } from '@nestjs/common';
-import { CreateReviewDto } from './dtos/create-review-dto';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { Review } from './entities/review.entity';
+import {
+  Application,
+  ApplicationStatus,
+} from '../application/entities/application.entity';
+import { CreateReviewDto } from './dtos/create-review-dto';
+import { InternalServerErrorException } from '@nestjs/common';
 
 @Injectable()
 export class ReviewService {
+  constructor(
+    @InjectRepository(Review)
+    private reviewRepository: Repository<Review>,
+    @InjectRepository(Application)
+    private applicationRepository: Repository<Application>,
+  ) {}
+
   async createReview(
     traineeUserId: string,
     createReviewDto: CreateReviewDto,
   ): Promise<Review> {
-    console.log(traineeUserId);
-    console.log(createReviewDto);
-    return Promise.resolve(null);
+    const { applicationId, comment, rating } = createReviewDto;
+
+    const application = await this.applicationRepository.findOne(
+      applicationId,
+      { relations: ['trainee', 'course', 'course.trainer'] },
+    );
+
+    if (!application) {
+      throw new NotFoundException('The application was not found');
+    }
+    if (traineeUserId !== application.traineeUserId) {
+      throw new BadRequestException(
+        `The trainee doesn't match with one in the application`,
+      );
+    }
+    if (application.status !== ApplicationStatus.COMPLETE) {
+      throw new ForbiddenException(`The application's status was not complete`);
+    }
+
+    const review = this.reviewRepository.create();
+
+    review.trainer = application.course.trainer;
+    review.trainee = application.trainee;
+    review.application = application;
+    review.rating = rating;
+    review.comment = comment;
+
+    try {
+      // TODO: Add serialization for response
+      return await this.reviewRepository.save(review);
+    } catch (error) {
+      if (error.code === 'ER_DUP_ENTRY') {
+        throw new BadRequestException(
+          'The review of appliation already exists',
+        );
+      } else {
+        throw new InternalServerErrorException();
+      }
+    }
   }
 
   async getReviewsByTrainerId(

--- a/backend/src/review/review.service.ts
+++ b/backend/src/review/review.service.ts
@@ -60,7 +60,7 @@ export class ReviewService {
       return await this.reviewRepository.save(review);
     } catch (error) {
       if (error.code === 'ER_DUP_ENTRY') {
-        throw new ConflictException('The review of appliation already exists');
+        throw new ConflictException('The review of application already exists');
       } else {
         throw new InternalServerErrorException();
       }


### PR DESCRIPTION
## Summary
Implement **US5-1** `createReview` service
## Changes
- backend/mysql-script/1-init.sql
  - Add column `application_id`
- backend/mysql-script/3-data.sql
  - Add `application` mock (status is complete)
  - Temporary disable `review` mock
- backend/src/review/dtos/create-review-dto.ts
  - Remove `trainerUserId`
  - Add `applicationId`
- backend/src/review/entities/review.entity.ts
  - Add one-to-one relationship with `Application`
- backend/src/review/review.module.ts
  - Add typeorm feature for `Review` and `Application`
- backend/src/review/review.service.ts
  - Implement `createReview` service